### PR TITLE
Make the professor's name in class card more readable

### DIFF
--- a/assets/src/modules/sm/App/styles/global.css
+++ b/assets/src/modules/sm/App/styles/global.css
@@ -323,6 +323,10 @@ form {
 	cursor: pointer;
 }
 
+.label-professor {
+	font-weight: normal;
+}
+
 /* NEW SCHEDULES */
 
 div[schedule] .canvas-cont {
@@ -360,7 +364,6 @@ div[schedule] .schedule-loading {
 		display: block;	
 	}
 }
-
 
 /* BOOTSTRAP EXTENSIONS */
 .btn {

--- a/assets/src/modules/sm/Browse/templates/browse.html
+++ b/assets/src/modules/sm/Browse/templates/browse.html
@@ -76,7 +76,7 @@
 																				<h4 class="list-group-item-heading">{{$index + 1}}. {{course | courseNum}}-{{section.section}}</h4>
 																				<small>{{section.title}}</small>
 																				<p class="list-group-item-text label-line ">
-																					<span class="label label-default" ng-bind-html="section.instructor | RMPUrl"></span>
+																					<span class="label label-default label-professor" ng-bind-html="section.instructor | RMPUrl"></span>
 																				</p>
 																				<div ng-init="parsedTimes = (section.times | parseSectionTimes:true)">
 																					<div ng-repeat="time in parsedTimes" style="font-size: small">

--- a/assets/src/modules/sm/Generate/templates/courseselect.html
+++ b/assets/src/modules/sm/Generate/templates/courseselect.html
@@ -34,7 +34,7 @@
 							<h4 class="list-group-item-heading"><span course-detail-popover="section.id">{{$index + 1}}. {{section.courseNum}}</span></h4>
 							<small>{{section.title}}</small>
 							<p class="list-group-item-text label-line ">
-								<span class="label label-default" ng-bind-html="section.instructor | RMPUrl"></span>
+								<span class="label label-default label-professor" ng-bind-html="section.instructor | RMPUrl"></span>
 							</p>
 							<div ng-init="parsedTimes = (section.times | parseSectionTimes)">
 								<div ng-repeat="time in parsedTimes" style="font-size:small">{{time.days}} <span style="white-space:nowrap">{{time.start | formatTime}}-{{time.end | formatTime}}</span></div>

--- a/assets/src/modules/sm/Search/templates/search.html
+++ b/assets/src/modules/sm/Search/templates/search.html
@@ -189,7 +189,7 @@
 											<h4 class="list-group-item-heading"><span course-detail-popover="section.id">{{($index + 1) + (searchPagination.currentPage*searchPagination.pageSize)}}. {{section.courseNum}}</span></h4>
 											<small>{{section.title}}</small>
 											<p class="list-group-item-text label-line ">
-												<span class="label label-default" ng-bind-html="section.instructor | RMPUrl"></span>
+												<span class="label label-default label-professor" ng-bind-html="section.instructor | RMPUrl"></span>
 											</p>
 											<div ng-init="parsedTimes = (section.times | parseSectionTimes:true)">
 												<div ng-repeat="time in parsedTimes" style="font-size: small">


### PR DESCRIPTION
This sets the font weight to normal for the professor's name in class cards. The name was hard to read before and this cleans it up. This is applied to the browse, courseselect, and search templates.

Example:
![after](https://cloud.githubusercontent.com/assets/14286106/19752751/ae579130-9bcd-11e6-8442-02018528feba.PNG)
