### PR TITLE
Fixed rounding on event times in calendar

### DIFF
--- a/assets/src/modules/sm/Schedule/directives/scheduleDirective.js
+++ b/assets/src/modules/sm/Schedule/directives/scheduleDirective.js
@@ -122,16 +122,16 @@ angular.module('sm').directive('schedule', function($timeout, $filter) {
 			
 			// Calculate the height
 			var timeHeight = parseInt(courseEnd) - parseInt(courseStart);
-			timeHeight = timeHeight / 15;
+			timeHeight = timeHeight / 7.5;
 			timeHeight = Math.ceil(timeHeight);
 
-			timeHeight = (timeHeight * 10);
+			timeHeight = (timeHeight * 5);
 
 			// Calculate the top offset
 			var timeTop = parseInt(courseStart) - startTime;
-			timeTop = timeTop / 30;
+			timeTop = timeTop / 7.5;
 			timeTop = Math.floor(timeTop);
-			timeTop = timeTop * 20;
+			timeTop = timeTop * 5;
 			timeTop += 19;					// Offset for the header
 			
 			if(course.courseNum != 'non') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schedulemaker",
-  "version": "3.0.26",
+  "version": "3.0.27",
   "private": true,
   "description": "A course database lookup tool and schedule building web application for use at Rochester Institute of Technology.",
   "main": "index.php",


### PR DESCRIPTION
I fixed the rounding by getting it down significantly closer to accurate start/end times.
Also added a version bump to allow the fixes to properly display
Fixes #125

Proof of it working: https://schedule-matted.csh.rit.edu