### PR TITLE
Update master with more accurate course times in the schedule.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schedulemaker",
-  "version": "3.0.25",
+  "version": "3.0.26",
   "private": true,
   "description": "A course database lookup tool and schedule building web application for use at Rochester Institute of Technology.",
   "main": "index.php",


### PR DESCRIPTION
Looks good @devinmatte, deploying to prod!

I can say that since the times are more confusing and not lining up to the lines anymore, it could really use "3:05pm Class Name Here" in the title because now the times are not obvious. Maybe it would fit better in the location field on the next line. I'll open an issue for you to look at if you want.