### PR TITLE
Adding Start Time to event Card

### DIFF
--- a/assets/src/modules/sm/Schedule/directives/scheduleDirective.js
+++ b/assets/src/modules/sm/Schedule/directives/scheduleDirective.js
@@ -133,9 +133,32 @@ angular.module('sm').directive('schedule', function($timeout, $filter) {
 			timeTop = Math.floor(timeTop);
 			timeTop = timeTop * 5;
 			timeTop += 19;					// Offset for the header
-			
-			if(course.courseNum != 'non') {
-				var location = ((this.drawOptions.bldgStyle == 'code') ? time.bldg.code : time.bldg.number) + "-" + time.room,
+
+			//Add Padding for Formatting Time
+            function pad(d) {
+            	//Allows for time to display as example: 12:04 instead of 12:4
+                return (d < 10) ? '0' + d.toString() : d.toString();
+            }
+
+            //Format Start time
+            var hourLabel = Math.floor(courseStart / 60);
+            if(hourLabel > 12) {
+            	hourLabel -= 12;
+            }
+            else if(hourLabel == 0) {
+            	hourLabel = 12;
+            }
+            var minuteLabel = (courseStart % 60);
+            minuteLabel = pad(minuteLabel);
+            if(courseStart >= 720) {
+            	ap = " PM";
+            } else {
+            	ap = " AM";
+            }
+
+            //Set event data
+            if(course.courseNum != 'non') {
+				var location = ((this.drawOptions.bldgStyle == 'code') ? time.bldg.code : time.bldg.number) + "-" + time.room + " (" + (String(hourLabel) + ":" + String(minuteLabel) + " " + ap) + ")",
 				instructor = course.instructor,
 				courseNum = course.courseNum;
 			} else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schedulemaker",
-  "version": "3.0.27",
+  "version": "3.0.28",
   "private": true,
   "description": "A course database lookup tool and schedule building web application for use at Rochester Institute of Technology.",
   "main": "index.php",


### PR DESCRIPTION
Now that class start times are a little odd, the start time is now listed alongside the location in order to help avoid confusion.

### Adds time to the location section of an event:
![](https://csh.rit.edu/~matted/images/Schedule.png)
![](https://csh.rit.edu/~matted/images/event.png)

Fixes #129