### PR TITLE
Fixed iCal Generation

### DIFF
--- a/api/schedule.php
+++ b/api/schedule.php
@@ -34,7 +34,7 @@ function generateIcal($schedule) {
 
 	// We need to lookup the information about the quarter
 	$term = $dbConn->real_escape_string($schedule['term']);
-	$query = "SELECT start, end, breakstart, breakend FROM quarters WHERE quarter='{$term}'";
+	$query = "SELECT start, end FROM quarters WHERE quarter='{$term}'";
 	$result = $dbConn->query($query);
 	$term = $result->fetch_assoc();
 	$termStart = strtotime($term['start']);


### PR DESCRIPTION
Fixes #151.

Columns `breakstart` and `breakend` were removed from the `quarters` table in 591a2694bd503a4bc072606669feb08f55949f9c. 