### PR TITLE
Adding check to prevent generating 10000 Schedules

### DIFF
--- a/api/generate.php
+++ b/api/generate.php
@@ -391,6 +391,19 @@ switch(getAction()) {
 		$courseGroupsByCourseId = array();
 
 		$courseSet = array();
+
+		// Check to make sure schedule wont exceed 10,000 options
+        $totalSchedules = 1;
+        for($i = 1; $i <= $_POST['courseCount']; $i++) {
+            if(!isset($_POST["courses{$i}Opt"])) { continue; }
+            $totalSchedules *= count($_POST["courses{$i}Opt"]);
+        }
+        if ($totalSchedules >= 10000){
+            echo json_encode(array("error" => "argument", "msg" => "Too many schedule possibilities to generate, try to prune possibilities. 
+            Adding classes like YearOne or classes with hundreds of sections can cause this to occur.", "arg" => "action"));
+            break;
+        }
+
 		for($i = 1; $i <= $_POST['courseCount']; $i++) {		// It's 1-indexed... :[
 			// Iterate over the courses in that course slot
 			if(!isset($_POST["courses{$i}Opt"])) { continue; }

--- a/api/generate.php
+++ b/api/generate.php
@@ -399,7 +399,7 @@ switch(getAction()) {
             $totalSchedules *= count($_POST["courses{$i}Opt"]);
         }
         if ($totalSchedules >= 10000){
-            echo json_encode(array("error" => "argument", "msg" => "Too many schedule possibilities to generate, try to prune possibilities. 
+            echo json_encode(array("error" => "argument", "msg" => "Too many schedule possibilities to generate, try to remove classes from your shopping cart. 
             Adding classes like YearOne or classes with hundreds of sections can cause this to occur.", "arg" => "action"));
             break;
         }


### PR DESCRIPTION
Adds a simple check that before actually running through a result, PHP stops and returns an error

This will prevent super large schedules from being generated, as well as reducing processing on the sever from people generating the super large options.

Fixes #133 