### PR TITLE
Updating angular to 1.4.14

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -152,7 +152,7 @@ gulp.task('styles', function (done) {
     return gulp.src(stylePaths.src)
       .pipe(concat('dist.css'))
       .pipe(gulp.dest(stylePaths.dest))
-      .pipe(minifyCSS({ processImport: false }))
+      .pipe(minifyCSS({ advanced: false, processImport: true, keepSpecialComments: 0 }))
       .pipe(rename({ suffix: '.min' }))
       .pipe(gulp.dest(stylePaths.dest))
   })

--- a/index.php
+++ b/index.php
@@ -143,10 +143,10 @@ if ($path[1] == 'schedule') {
 		<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
 		<script src="//cdnjs.cloudflare.com/ajax/libs/mousetrap/1.4.6/mousetrap.min.js"></script>
 		<script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
-		<script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.3.20/angular.min.js"></script>
-		<script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.3.20/angular-animate.min.js"></script>
-		<script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.3.20/angular-sanitize.min.js"></script>
-		<script src="//cdnjs.cloudflare.com/ajax/libs/angular-ui-router/0.3.2/angular-ui-router.min.js"></script>
+		<script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.4.14/angular.min.js"></script>
+		<script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.4.14/angular-animate.min.js"></script>
+		<script src="//cdnjs.cloudflare.com/ajax/libs/angular.js/1.4.14/angular-sanitize.min.js"></script>
+		<script src="//cdnjs.cloudflare.com/ajax/libs/angular-ui-router/0.4.2/angular-ui-router.min.js"></script>
         <script src="<?=$ASSETROOTADDRESS?>assets/prod/<?=$APP_VERSION?>/modules/sm/dist.min.js"></script>
 	</body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schedulemaker",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "private": true,
   "description": "A course database lookup tool and schedule building web application for use at Rochester Institute of Technology.",
   "main": "index.php",


### PR DESCRIPTION
Moving up one more version. At 1.5 we can add TS checks to most of the codebase which will make future updates safer.

I found very little I needed to change with 1.4, and the migration docs seem to agree https://code.angularjs.org/1.4.6/docs/guide/migration