### PR TITLE
temporarily remove ical download until it is fixed

### DIFF
--- a/assets/src/modules/sm/Schedule/templates/scheduleitem.html
+++ b/assets/src/modules/sm/Schedule/templates/scheduleitem.html
@@ -10,7 +10,7 @@
 							<span class="caret"></span>
 						</button>
 						<ul class="dropdown-menu" role="menu">
-							<li><a ng-click="scheduleActions.downloadiCal($event)" href="#"><i class="fa fa-fw fa-calendar-o"></i> iCal</a></li>
+							<!-- <li><a ng-click="scheduleActions.downloadiCal($event)" href="#"><i class="fa fa-fw fa-calendar-o"></i> iCal</a></li> -->
 							<li ng-show="imageSupport"><a ng-click="scheduleActions.downloadImage($event)" href="#"><i class="fa fa-fw fa-picture-o"></i> Image</a></li>
 						</ul>
 					</div>


### PR DESCRIPTION
Based on the discussion in #310, here is a small code change to remove the ICS button until it is fixed because this can cause people to assume the import worked and be surprised when realizing it doesnt.

alternatives include linking the button to issue 310 instead of the action to trigger the download

change untested, but so simple that its probably fine