### PR TITLE
Update Schedule.php to exclude holidays from iCal schedules

### DIFF
--- a/api/src/Schedule.php
+++ b/api/src/Schedule.php
@@ -102,6 +102,8 @@ class Schedule
 
                 $code .= "DTSTART;TZID=America/New_York:{$day}T{$startTime}\r\n";
                 $code .= "DTEND;TZID=America/New_York:{$day}T{$endTime}\r\n";
+                //$holidayTimes is an array of DateTimes that are listed as holidays in RIT's calendar.
+                $code .= "EXDATE:{$holidayTimes}\r\n";
                 $dayCodes = array('SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA');
                 $days = array();
                 foreach ($times as $time) {


### PR DESCRIPTION
Completes #344

This takes an array of DateTimes that should be excluded from the schedules, like University holidays [(calendar link here)](https://www.rit.edu/calendar), and adds it to the generated iCal files so that class events will not be created on those days off. Using the [iCal spec EXDATE](https://icalendar.org/iCalendar-RFC-5545/3-8-5-1-exception-date-times.html), we can skip those days and make sure not to confuse students.

It is up to you how to source the arrray of DateTimes to exclude. I have named the placeholder variable `$holidayTimes`.