### PR TITLE
search: fix sections which start at exactly 5 PM

### DIFF
--- a/api/search.php
+++ b/api/search.php
@@ -146,7 +146,7 @@ switch (getAction()) {
                 $timequery[] = "(start >= 720 AND start < 1020)";
             }
             if (in_array("even", $times)) {
-                $timequery[] = "(start > 1020)";
+                $timequery[] = "(start >= 1020)";
             }
             $timeConstraints[] = "(" . implode(" OR ", $timequery) . ")"; // Make it a single string (condition OR condition ...)
         }


### PR DESCRIPTION
## What

sections that start at 5 PM should count as at least one of
afternoon or evening.

## Why

says on the tin

## Test Plan

didn't

## Env Vars

nope

## Documentation

nada

## Checklist

- [ ] Tested all changes locally
